### PR TITLE
Tiny Fixes

### DIFF
--- a/Contents.swift
+++ b/Contents.swift
@@ -69,6 +69,11 @@ class ChatCell: UITableViewCell {
     }
 }
 
+extension ChatCell {
+    override var textLabel: UILabel? { return messageLabel }
+    override var imageView: UIImageView? { return iconImageView }
+}
+
 class MyViewController : UIViewController, UITableViewDelegate, UITableViewDataSource {
 
     lazy var tableView: UITableView = {

--- a/Contents.swift
+++ b/Contents.swift
@@ -10,6 +10,7 @@ class ChatCell: UITableViewCell {
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.backgroundColor = .clear
         imageView.layer.cornerRadius = 25
+        imageView.layer.masksToBounds = true
         imageView.contentMode = .scaleAspectFit
         imageView.image = icon
 


### PR DESCRIPTION
Adds `masksToBounds` which is necessary to have rounded icon show as rounded.

Also adds safety/sanity overrides to avoid clients accidentally using the default `UITableViewCell` getters.

Big thanks for providing this playground!